### PR TITLE
Added exception of char "&" in urlEncoded.

### DIFF
--- a/foundation/src/extensions/StringCollection.swift
+++ b/foundation/src/extensions/StringCollection.swift
@@ -25,7 +25,7 @@ extension String{
     }
     
     public func urlEncoded(_ characterSet:CharacterSet = .urlHostAllowed) -> String? {
-        addingPercentEncoding(withAllowedCharacters: characterSet)
+        addingPercentEncoding(withAllowedCharacters: characterSet)?.replace("&", "%26")
     }
 
     public func fromBase64() -> String? {


### PR DESCRIPTION
Error in move&flow, parsing data in register customer. 
Char "&" needs to be encoded to not conflict with parsing data.
StringCollection (RevoFoundation) -> urlEncoded (addingPercentEncoding) does not encode char "&". Added exception.

!!!!QUAN FACIS MERGE, PENJA VERSIÓ DE LA LLIBRERIA!!!!