### PR TITLE
Wrap container actions with sync to lock them and prevent crashes

### DIFF
--- a/foundation/src/services/Container.swift
+++ b/foundation/src/services/Container.swift
@@ -9,45 +9,68 @@ public protocol Resolvable{
 public class Container {
     
     public static var shared = Container()
-    
+
+    /// Protects `resolvers`, `singletons`, and `extensions`. Recursive so extension hooks can call `resolve` without deadlocking.
+    private let lock = NSRecursiveLock()
+
     var resolvers:[String : Any] = [:]
     var singletons:[String : Any] = [:]
     var extensions:[String : Any] = [:]
+
+    private func sync<R>(_ body: () throws -> R) rethrows -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body()
+    }
     
     // MARK:- Binding
     public func bind<T:Resolvable, Z:Resolvable>(_ type:T.Type, _ resolver:Z.Type) {
-        resolvers[String(describing: type)] = resolver
+        sync {
+            resolvers[String(describing: type)] = resolver
+        }
     }
     
     @discardableResult
     public func bind<T:Resolvable>(_ type:T.Type, _ resolver:T) -> T {
-        resolvers[String(describing: type)] = resolver
+        sync {
+            resolvers[String(describing: type)] = resolver
+        }
         return resolver
     }
     
     public func bind<T>(_ type:T.Type, _ clousure:@escaping()->T) {
-        resolvers[String(describing: type)] = clousure
+        sync {
+            resolvers[String(describing: type)] = clousure
+        }
     }
     
     public func bind<T>(singleton type:T.Type, _ clousure:@escaping()->T) {
-        singletons[String(describing: type)] = clousure
+        sync {
+            singletons[String(describing: type)] = clousure
+        }
     }
     
     public func bind<T, Z>(instance type:T.Type, _ resolver:Z) {
-        resolvers[String(describing: type)] = resolver
+        sync {
+            resolvers[String(describing: type)] = resolver
+        }
     }
       
     // MARK:- Extension
     public func extend<T>(_ type:T.Type, theExtension:@escaping (_ resolved:T)->Void){
-        extensions[String(describing: type)] = theExtension
+        sync {
+            extensions[String(describing: type)] = theExtension
+        }
     }
     
     func extend<T,Z>(for type:T.Type, resolved:Z) -> Z {
-        guard let theExtension = extensions[String(describing: type)] else {
+        sync {
+            guard let theExtension = extensions[String(describing: type)] else {
+                return resolved
+            }
+            (theExtension as! (_ value:Z)->Void)(resolved)
             return resolved
         }
-        (theExtension as! (_ value:Z)->Void)(resolved)
-        return resolved
     }
     
     // MARK:- Resolving
@@ -57,38 +80,41 @@ public class Container {
     }
     
     public func resolve<T>(withoutExtension type:T.Type) -> T? {
-        
-        if let singleTonclousure = singletons[String(describing: type)] as? (()->T) {
-            resolvers[String(describing: type)] = singleTonclousure()
-            singletons[String(describing: type)] = nil
-        }
-            
-        guard let resolver = resolvers[String(describing: type)] else {
-            if type.self is Resolvable.Type {
-                return (type as! Resolvable.Type).init() as? T
+        sync {
+            if let singleTonclousure = singletons[String(describing: type)] as? (()->T) {
+                resolvers[String(describing: type)] = singleTonclousure()
+                singletons[String(describing: type)] = nil
+            }
+                
+            guard let resolver = resolvers[String(describing: type)] else {
+                if type.self is Resolvable.Type {
+                    return (type as! Resolvable.Type).init() as? T
+                }
+                return nil
+            }
+            if let resolvable = resolver as? Resolvable.Type {
+                return resolvable.init() as? T
+            }
+            if let resolvable = resolver as? T {
+                return resolvable
+            }
+            if let resolvable = resolver as? (()->T) {
+                return resolvable()
             }
             return nil
         }
-        if let resolvable = resolver as? Resolvable.Type {
-            return resolvable.init() as? T
-        }
-        if let resolvable = resolver as? T {
-            return resolvable
-        }
-        if let resolvable = resolver as? (()->T) {
-            return resolvable()
-        }
-        return nil
     }
     
     public func resolver<T, Z>(for type:T.Type, ofProtocol:Z.Type) -> Z.Type?{
-        guard let resolver = resolvers[String(describing: type)] else {
+        sync {
+            guard let resolver = resolvers[String(describing: type)] else {
+                return nil
+            }
+            if let resolvable = resolver as? Z.Type {
+                return resolvable
+            }
             return nil
         }
-        if let resolvable = resolver as? Z.Type {
-            return resolvable
-        }
-        return nil
     }
 }
 
@@ -101,4 +127,3 @@ public struct Inject<Value>{
         wrappedValue = Container.shared.resolve(Value.self)
     }
 }
-


### PR DESCRIPTION
Linear: [REV-23646](https://linear.app/revo/issue/REV-23646/canvi-a-paquet-foundation-crash-al-accedir-a-la-comanda-despres)